### PR TITLE
add moreblocks optional depend and backwards compatibility

### DIFF
--- a/.luacheckrc
+++ b/.luacheckrc
@@ -10,5 +10,7 @@ read_globals = {
 
 	-- deps
 	"minetest",
-	"doors"
+	"doors",
+	"stairsplus",
+	"default"
 }

--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ This mod depends on:
 
  * default (included in minetest_game)
  * doors (included in minetest_game)
+ * moreblocks (optional)
 
 ## License
 

--- a/init.lua
+++ b/init.lua
@@ -22,6 +22,91 @@ minetest.register_node("prefab:concrete", {
 	groups = {cracky=2},
 })
 
+if minetest.get_modpath("moreblocks") then
+  -- moreblocks available
+  stairsplus:register_all("prefab", "concrete", "prefab:concrete", {
+    description = "Prefab Concrete",
+    tiles = {"prefab_concrete.png"},
+    groups = {cracky=2}
+  })
+
+  -- compat for old worlds, alias normal stairs and slabs to moreblocks variant
+  minetest.register_alias("prefab:concrete_stair", "prefab:stair_concrete")
+  minetest.register_alias("prefab:concrete_slab", "prefab:slab_concrete")
+
+else
+  -- no moreblocks
+  minetest.register_node("prefab:concrete_stair", {
+    drawtype = "nodebox",
+    description = "Prefab Concrete Stair",
+    tiles = {"prefab_concrete.png"},
+    paramtype = "light",
+    paramtype2 = "facedir",
+    node_box = {
+      type = "fixed",
+      fixed = {
+        {-0.500000,-0.500000,-0.500000,0.500000,-0.000000,0.500000},
+        {-0.500000,-0.500000,0.000000,0.500000,0.500000,0.500000},
+      },
+    },
+    is_ground_content = false,
+    drop = "prefab:concrete_stair",
+    groups = {cracky=2},
+  })
+
+  minetest.register_node("prefab:concrete_slab", {
+    drawtype = "nodebox",
+    description = "Prefab Concrete Slab",
+    tiles = {"prefab_concrete.png"},
+    paramtype = "light",
+    node_box = {
+      type = "fixed",
+      fixed = {
+        {-0.500000,-0.500000,-0.500000,0.500000,0.000000,0.500000},
+      },
+    },
+    is_ground_content = false,
+    drop = "prefab:concrete_slab",
+    groups = {cracky=2},
+  })
+
+end
+
+minetest.register_node("prefab:concrete_slab_inverted", {
+  drawtype = "nodebox",
+  description = "Prefab Concrete Slab (inverted)",
+  tiles = {"prefab_concrete.png"},
+  paramtype = "light",
+  node_box = {
+    type = "fixed",
+    fixed = {
+      {-0.500000,0.000000,-0.500000,0.500000,0.500000,0.500000},
+    },
+  },
+  is_ground_content = false,
+  drop = "prefab:concrete_slab",
+  groups = {cracky=2},
+})
+
+minetest.register_node("prefab:concrete_stair_inverted", {
+  drawtype = "nodebox",
+  description = "Prefab Concrete Stair (inverted)",
+  tiles = {"prefab_concrete.png"},
+  paramtype = "light",
+  paramtype2 = "facedir",
+  node_box = {
+    type = "fixed",
+    fixed = {
+      {-0.500000,0.000000,-0.500000,0.500000,0.500000,0.500000},
+      {-0.500000,-0.500000,-0.062500,0.500000,0.500000,0.500000},
+    },
+  },
+  is_ground_content = false,
+  drop = "prefab:concrete_stair",
+  groups = {cracky=2},
+})
+
+
 minetest.register_node("prefab:concrete_with_grass", {
 	description = "Prefab Concrete with Grass",
 	paramtype = "light",
@@ -52,74 +137,6 @@ minetest.register_node("prefab:concrete_wall", {
 	},
 	is_ground_content = false,
 	drop = "prefab:concrete_wall",
-	groups = {cracky=2},
-})
-
-minetest.register_node("prefab:concrete_stair", {
-        drawtype = "nodebox",
-	description = "Prefab Concrete Stair",
-	tiles = {"prefab_concrete.png"},
-	paramtype = "light",
-    paramtype2 = "facedir",
-	node_box = {
-		type = "fixed",
-		fixed = {
-			{-0.500000,-0.500000,-0.500000,0.500000,-0.000000,0.500000},
-			{-0.500000,-0.500000,0.000000,0.500000,0.500000,0.500000},
-		},
-	},
-	is_ground_content = false,
-	drop = "prefab:concrete_stair",
-	groups = {cracky=2},
-})
-
-minetest.register_node("prefab:concrete_slab", {
-        drawtype = "nodebox",
-	description = "Prefab Concrete Slab",
-	tiles = {"prefab_concrete.png"},
-	paramtype = "light",
-	node_box = {
-		type = "fixed",
-		fixed = {
-			{-0.500000,-0.500000,-0.500000,0.500000,0.000000,0.500000},
-		},
-	},
-	is_ground_content = false,
-	drop = "prefab:concrete_slab",
-	groups = {cracky=2},
-})
-
-minetest.register_node("prefab:concrete_stair_inverted", {
-        drawtype = "nodebox",
-	description = "Prefab Concrete Stair (inverted)",
-	tiles = {"prefab_concrete.png"},
-	paramtype = "light",
-	paramtype2 = "facedir",
-	node_box = {
-		type = "fixed",
-		fixed = {
-			{-0.500000,0.000000,-0.500000,0.500000,0.500000,0.500000},
-			{-0.500000,-0.500000,-0.062500,0.500000,0.500000,0.500000},
-		},
-	},
-	is_ground_content = false,
-	drop = "prefab:concrete_stair",
-	groups = {cracky=2},
-})
-
-minetest.register_node("prefab:concrete_slab_inverted", {
-        drawtype = "nodebox",
-	description = "Prefab Concrete Slab (inverted)",
-	tiles = {"prefab_concrete.png"},
-	paramtype = "light",
-	node_box = {
-		type = "fixed",
-		fixed = {
-			{-0.500000,0.000000,-0.500000,0.500000,0.500000,0.500000},
-		},
-	},
-	is_ground_content = false,
-	drop = "prefab:concrete_slab",
 	groups = {cracky=2},
 })
 

--- a/mod.conf
+++ b/mod.conf
@@ -1,3 +1,4 @@
 name = prefab
 depends = default, doors
+optional_depends = moreblocks
 description = Adds pre-fabricated concrete elements.


### PR DESCRIPTION
* adds `moreblocks` as optional depends

If `moreblocks` is available:
* registers `prefab:concrete` for all shapes
* aliases `prefab:concrete_stair` and `prefab:concrete_slab` to the moreblocks variant
* the inverted variant of the stairs and slabs are omitted (would need some abm magic)